### PR TITLE
Fix load events in script.js

### DIFF
--- a/script.js
+++ b/script.js
@@ -56,7 +56,8 @@ function loadSections() {
     .then(() => toggleTopButton());
 }
 
-loadSections();
+// Ensure all sections are loaded only after the DOM is fully parsed
+document.addEventListener("DOMContentLoaded", loadSections);
 
 // Scroll to the top of the document
 function scrollToTop() {
@@ -82,11 +83,15 @@ window.onscroll = function () {
 };
 
 // Call the "scrollToTop" function when the "Go to top" button is clicked
-window.onload = function () {
-  document.getElementById("goToTopButton").onclick = function () {
-    scrollToTop();
-  };
-};
+// Ensure other onload handlers are preserved
+window.addEventListener("load", function () {
+  var goToTopButton = document.getElementById("goToTopButton");
+  if (goToTopButton) {
+    goToTopButton.onclick = function () {
+      scrollToTop();
+    };
+  }
+});
 
 document.addEventListener("DOMContentLoaded", function () {
   var goToTopButton = document.getElementById("goToTopButton");


### PR DESCRIPTION
## Summary
- load page sections after DOM content is ready
- use `window.addEventListener('load', …)` for go-to-top button so other `onload` handlers aren't overwritten

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_685bcea242c4832bae7b4ed02125fb0d