### PR TITLE
Refine locale switcher with pill buttons

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/components/BackToTopButton.tsx
+++ b/components/BackToTopButton.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react';
+import { useTranslations } from '../lib/i18n';
 
 const BackToTopButton = (): JSX.Element => {
   const [isVisible, setIsVisible] = useState<boolean>(false);
+  const { title } = useTranslations('BackToTop');
 
   useEffect(() => {
     const handleScroll = () => {
@@ -28,7 +30,7 @@ const BackToTopButton = (): JSX.Element => {
   return (
     <button
       id="goToTopButton"
-      title="Go to top"
+      title={title}
       onClick={scrollToTop}
       style={{ display: isVisible ? 'flex' : 'none' }}
     >

--- a/components/ContactMe.tsx
+++ b/components/ContactMe.tsx
@@ -1,26 +1,27 @@
+import { useTranslations } from '../lib/i18n';
+
 const ContactMe = (): JSX.Element => {
+  const { title, subtitle, quote, description, location } = useTranslations('Contact');
+
   return (
     <>
-      <h1>Reach out to me!</h1>
+      <h1>{title}</h1>
 
       <div className="reach-out-card-right col-md-4">
         <img className="profile-photo" src="/assets/profile-photo/photo-me.png" alt="Profile" />
       </div>
 
       <div className="reach-out-card-left col-md-8">
-        <p className="blog-subtitle">DISCUSS A PROJECT OR JUST WANT TO SAY HI? MY INBOX IS OPEN FOR ALL.</p>
-        <h4>"Software Developer | Still Finding 💭 "</h4>
-        <p>
-          I currently work for a company as a frontend developer on ecommerce projects and I'm following 3 courses on
-          udemy: React native, Nextjs framework, nodejs.
-        </p>
+        <p className="blog-subtitle">{subtitle}</p>
+        <h4>{quote}</h4>
+        <p>{description}</p>
         <svg viewBox="-0.5 -2 20 19" version="1.1" width="22" height="16" aria-hidden="true" stroke="currentColor">
           <path
             fillRule="evenodd"
             d="M6 0C2.69 0 0 2.5 0 5.5 0 10.02 6 16 6 16s6-5.98 6-10.5C12 2.5 9.31 0 6 0zm0 14.55C4.14 12.52 1 8.44 1 5.5 1 3.02 3.25 1 6 1c1.34 0 2.61.48 3.56 1.36.92.86 1.44 1.97 1.44 3.14 0 2.94-3.14 7.02-5 9.05zM8 5.5c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"
           ></path>
         </svg>
-        Bologna, Italy
+        {location}
 
         <div className="social-media-div col-sm-12">
           <a className="social-media-icons" href="https://github.com/jojoCan94" target="_blank" rel="noopener noreferrer">

--- a/components/Education.tsx
+++ b/components/Education.tsx
@@ -1,22 +1,23 @@
+import { useTranslations } from '../lib/i18n';
+
 const Education = (): JSX.Element => {
+  const { title, card } = useTranslations('Education');
+
   return (
     <section className="education-section text-white">
-      <h1 style={{ marginTop: '4rem', marginBottom: '4rem' }}>EDUCATION</h1>
+      <h1 style={{ marginTop: '4rem', marginBottom: '4rem' }}>{title}</h1>
       <div className="card p-3">
         <div className="education-card d-flex align-items-center flex-column text-center p-3">
           <img src="/assets/logo/unibo.jpg" alt="Education" width="150" />
           <div className="mt-3">
-            <h2 className="education-card-title mb-1">Alma Mater Studiorum- Universitaà degli studi di Bologna</h2>
-            <h3 className="education-card-subtitle mb-1 mt-4">Scienze inforrmatiche</h3>
-            <div className="education-card-date mb-3">2019 - 2021</div>
-            <p className="education-card-description">
-              I completed two years of the three-year Bachelor's degree program in Computer Science at the University
-              of Bologna, gaining a strong foundation in programming, computer security, and collaboration skills through
-              group projects.<br />
-              <br />
-              Although I completed only two years of studies, my experience at the University of Bologna was a
-              significant personal and professional growth opportunity.
-            </p>
+            <h2 className="education-card-title mb-1">{card.institution}</h2>
+            <h3 className="education-card-subtitle mb-1 mt-4">{card.course}</h3>
+            <div className="education-card-date mb-3">{card.period}</div>
+            {card.description.map((paragraph, index) => (
+              <p className="education-card-description" key={`${card.institution}-${index}`}>
+                {paragraph}
+              </p>
+            ))}
           </div>
         </div>
       </div>

--- a/components/Experiences.tsx
+++ b/components/Experiences.tsx
@@ -1,62 +1,66 @@
+import { useTranslations } from '../lib/i18n';
+
+type ExperienceKey = 'syscons' | 'nexum';
+
+type ExperienceCard = {
+  key: ExperienceKey;
+  imageSrc: string;
+  imageAlt: string;
+  frontClassName: string;
+  backClassName: string;
+  imageWidth: number;
+};
+
+const EXPERIENCE_CARDS: ExperienceCard[] = [
+  {
+    key: 'syscons',
+    imageSrc: '/assets/logo/work-logos/syscons-interactive.webp',
+    imageAlt: 'Syscons logo',
+    frontClassName: 'flip-card-front',
+    backClassName: 'flip-card-back',
+    imageWidth: 300,
+  },
+  {
+    key: 'nexum',
+    imageSrc: '/assets/logo/work-logos/nexum-logo.jpeg',
+    imageAlt: 'Nexum logo',
+    frontClassName: 'flip-card-front-nex',
+    backClassName: 'flip-card-back-nex',
+    imageWidth: 180,
+  },
+];
+
 const Experiences = (): JSX.Element => {
+  const { title, cards } = useTranslations('Experiences');
+
   return (
     <>
-      <h1>Experiences</h1>
+      <h1>{title}</h1>
 
       <div className="work-experience">
-        <div className="flip-card">
-          <div className="flip-card-inner">
-            <div className="flip-card-front">
-              <img
-                className="work-logo title"
-                src="/assets/logo/work-logos/syscons-interactive.webp"
-                alt="Syscons logo"
-                width="300"
-              />
-            </div>
-            <div className="flip-card-back">
-              <div className="card-info">
-                <div className="work-description">
-                  <h3>Frontend Developer</h3>
-                  <p className="work-job-title">Syscons Interactive</p>
-                  <p className="work-job-location">Via Francesco Restelli, 5, Milan, Italy</p>
-                  <p className="work-jod-desc">
-                    Here I worked on some internal products of the company and I specialized in HTML, CSS,
-                    React+Redux+saga+Typescript, branch and repo management on gitlab, google cloud, Api rest, TDD&e2e,
-                    jira platform(agile work)
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
+        {EXPERIENCE_CARDS.map((card) => {
+          const translations = cards[card.key];
 
-        <div className="flip-card">
-          <div className="flip-card-inner">
-            <div className="flip-card-front-nex">
-              <img
-                className="work-logo title rounded-circle"
-                src="/assets/logo/work-logos/nexum-logo.jpeg"
-                alt="Nexum logo"
-                width="180"
-              />
-            </div>
-            <div className="flip-card-back-nex">
-              <div className="card-info">
-                <div className="work-description">
-                  <h3>Cloud Frontend Developer</h3>
-                  <p className="work-job-title">Nexum-ai</p>
-                  <p className="work-job-location">Via Rodi, 49 - 00195 Rome, Italy</p>
-                  <p className="work-jod-desc">
-                    Here I worked on some internal products of the company and I specialize in HTML, CSS,
-                    React+Redux+saga+Typescript, branch and repo management on gitlab, google cloud, Api rest, TDD&e2e,
-                    jira platform(agile work)
-                  </p>
+          return (
+            <div className="flip-card" key={card.key}>
+              <div className="flip-card-inner">
+                <div className={card.frontClassName}>
+                  <img className="work-logo title" src={card.imageSrc} alt={card.imageAlt} width={card.imageWidth} />
+                </div>
+                <div className={card.backClassName}>
+                  <div className="card-info">
+                    <div className="work-description">
+                      <h3>{translations.role}</h3>
+                      <p className="work-job-title">{translations.company}</p>
+                      <p className="work-job-location">{translations.location}</p>
+                      <p className="work-jod-desc">{translations.description}</p>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        </div>
+          );
+        })}
       </div>
     </>
   );

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,10 +1,14 @@
+import { useTranslations } from '../lib/i18n';
+
 const Footer = (): JSX.Element => {
+  const { crafted, themeCredit } = useTranslations('Footer');
+
   return (
     <footer className="footer">
       <div className="container">
-        <div className="col-sm copyright">✍️ with ❤️ by Me</div>
+        <div className="col-sm copyright">{crafted}</div>
         <div className="col-sm social-icons">
-          Theme inspired by{' '}
+          {themeCredit}{' '}
           <a href="https://github.com/saadpasta/developerFolio" target="_blank" rel="noopener noreferrer">
             developerFolio
           </a>

--- a/components/Greeting.tsx
+++ b/components/Greeting.tsx
@@ -1,4 +1,8 @@
+import { useTranslations } from '../lib/i18n';
+
 const Greeting = (): JSX.Element => {
+  const { title, intro, skills, resumeCta, resumeUrl, contactCta, contactEmail } = useTranslations('Greeting');
+
   return (
     <div className="greeting-main text-white">
       <div className="row flex-lg-row flex-column justify-content-lg-start justify-content-center">
@@ -7,16 +11,14 @@ const Greeting = (): JSX.Element => {
             className="greeting-title display-1 text-lg text-md text-sm fw-bold mb-4"
             style={{ fontSize: 'calc(1.625rem + 2vw)' }}
           >
-            Hi all, I'm Jonathan <span className="wave">👋</span>
+            {title} <span className="wave">👋</span>
           </h1>
           <p className="greeting-text lead mb-4" style={{ fontSize: '1.25rem', marginTop: '1rem', width: '100%' }}>
-            I am a Frontend Software Developer 🚀 with experience in JavaScript, React.js, Node.js, and other
-            libraries and frameworks. I create user-friendly and performant interfaces to enhance user experience.
+            {intro}
           </p>
 
           <p className="skills-text lead mb-4" style={{ fontSize: '1.25rem', marginTop: '1rem', width: '100%' }}>
-            My skills include responsive web development, and accessibility. I stay up-to-date with the latest
-            frontend technologies and trends, always seeking new challenges to improve my skills.
+            {skills}
           </p>
 
           <div className="social-media-div mb-4">
@@ -47,17 +49,14 @@ const Greeting = (): JSX.Element => {
           </div>
           <div className="button-presentation mb-4">
             <button className="btn-custom">
-              <a
-                href="http://drive.google.com/file/d/1eavvNPP9TE-ALrtxx7IPc1vQp0Lwonwg/view?usp=sharing"
-                className="text-white"
-              >
-                SEE MY RESUME
+              <a href={resumeUrl} className="text-white">
+                {resumeCta}
               </a>
             </button>
 
             <button className="btn-custom2">
-              <a href="mailto:jojo.can.94@gmail.com" className="text-white">
-                CONTACT ME
+              <a href={`mailto:${contactEmail}`} className="text-white">
+                {contactCta}
               </a>
             </button>
           </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,23 +1,37 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useTranslations } from '../lib/i18n';
+import { SUPPORTED_LOCALES, type Locale } from '../lib/messages';
+
+type NavLinkKey = 'skills' | 'experiences' | 'projects' | 'contacts';
+
 type NavLink = {
   href: string;
   icon: string;
-  label: string;
+  labelKey: NavLinkKey;
 };
 
 const NAV_LINKS: NavLink[] = [
-  { href: '#skills', icon: 'fas fa-code', label: 'Skills' },
-  { href: '#experiences', icon: 'fas fa-briefcase', label: 'Works' },
-  { href: '#projects', icon: 'fas fa-laptop-code', label: 'Projects' },
-  { href: '#contact-me', icon: 'fas fa-envelope', label: 'Contacts' },
+  { href: '#skills', icon: 'fas fa-code', labelKey: 'skills' },
+  { href: '#experiences', icon: 'fas fa-briefcase', labelKey: 'experiences' },
+  { href: '#projects', icon: 'fas fa-laptop-code', labelKey: 'projects' },
+  { href: '#contact-me', icon: 'fas fa-envelope', labelKey: 'contacts' },
 ];
 
 const Header = (): JSX.Element => {
+  const router = useRouter();
+  const { asPath, locale, locales } = router;
+  const { brand, links, language } = useTranslations('Header');
+  const availableLocales = (locales ?? SUPPORTED_LOCALES).filter((availableLocale): availableLocale is Locale =>
+    SUPPORTED_LOCALES.includes(availableLocale as Locale),
+  );
+
   return (
     <header id="header" className="header-main">
       <nav className="navbar navbar-expand-md navbar-dark">
         <div className="container-fluid">
           <a className="navbar-brand" href="#">
-            JC Dev
+            {brand}
           </a>
           <button
             className="navbar-toggler"
@@ -35,10 +49,30 @@ const Header = (): JSX.Element => {
               {NAV_LINKS.map((link) => (
                 <li className="nav-item" key={link.href}>
                   <a className="nav-link text-center text-xxl-h3 text-xl-h4 text-lg-h5 text-sm-h6" href={link.href}>
-                    <i className={link.icon} /> {link.label}
+                    <i className={link.icon} /> {links[link.labelKey]}
                   </a>
                 </li>
               ))}
+              <li className="nav-item d-flex align-items-center ms-md-3" key="locale-switcher">
+                <div className="btn-group btn-group-sm" role="group" aria-label="Language switcher">
+                  {availableLocales.map((availableLocale) => {
+                    const isActive = availableLocale === locale;
+                    const label = language[availableLocale] ?? availableLocale.toUpperCase();
+
+                    return (
+                      <Link
+                        key={availableLocale}
+                        href={asPath}
+                        locale={availableLocale}
+                        className={`btn ${isActive ? 'btn-light text-dark' : 'btn-outline-light'}`}
+                        aria-current={isActive ? 'true' : undefined}
+                      >
+                        {label}
+                      </Link>
+                    );
+                  })}
+                </div>
+              </li>
             </ul>
           </div>
         </div>

--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -1,26 +1,24 @@
+import { useTranslations } from '../lib/i18n';
+
+type ProjectKey = 'portfolio' | 'todo' | 'api';
+
+const PROJECTS: ProjectKey[] = ['portfolio', 'todo', 'api'];
+
 const Projects = (): JSX.Element => {
+  const { title, cards } = useTranslations('Projects');
+
   return (
     <section className="projects-section">
-      <h1>Projects</h1>
+      <h1>{title}</h1>
       <div className="row">
-        <div className="col-md-4 mb-3">
-          <div className="project-card h-100">
-            <h3>Personal Portfolio</h3>
-            <p>A simple website built to showcase my work and skills.</p>
+        {PROJECTS.map((projectKey) => (
+          <div className="col-md-4 mb-3" key={projectKey}>
+            <div className="project-card h-100">
+              <h3>{cards[projectKey].title}</h3>
+              <p>{cards[projectKey].description}</p>
+            </div>
           </div>
-        </div>
-        <div className="col-md-4 mb-3">
-          <div className="project-card h-100">
-            <h3>Todo App</h3>
-            <p>Web application for managing daily tasks using React.</p>
-          </div>
-        </div>
-        <div className="col-md-4 mb-3">
-          <div className="project-card h-100">
-            <h3>API Experiment</h3>
-            <p>Small project to explore REST API integration with Node.js.</p>
-          </div>
-        </div>
+        ))}
       </div>
     </section>
   );

--- a/components/Skills.tsx
+++ b/components/Skills.tsx
@@ -1,11 +1,13 @@
+import { useTranslations } from '../lib/i18n';
+
 const Skills = (): JSX.Element => {
+  const { title, intro, highlight1, highlight2, highlight3, highlight4 } = useTranslations('Skills');
+
   return (
     <>
-      <h1 className="skills-title col-md-12">What I Do</h1>
+      <h1 className="skills-title col-md-12">{title}</h1>
 
-      <p className="skills-paragraph">
-        I am incurably curious about both front-end and back-end technologies, but my absolute passion is front-end.
-      </p>
+      <p className="skills-paragraph">{intro}</p>
 
       <div className="mt-4">
         <ul className="d-flex justify-content-around p-3 skills-icon" style={{ listStyleType: 'none' }}>
@@ -39,18 +41,13 @@ const Skills = (): JSX.Element => {
         </ul>
       </div>
 
-      <p className="skills-explained mt-4">
-        ⚡ I develop highly interactive user interfaces for your web and mobile applications.
-      </p>
+      <p className="skills-explained mt-4">{highlight1}</p>
 
-      <p className="skills-explained">⚡ Progressive Web Applications (PWA) in normal and SPA stacks.</p>
+      <p className="skills-explained">{highlight2}</p>
 
-      <p className="skills-explained">⚡ Integration of third-party services such as Firebase/AWS/Digital Ocean.</p>
+      <p className="skills-explained">{highlight3}</p>
 
-      <p className="skills-explained">
-        ⚡ I also strive to optimize web accessibility and performance through the use of best practices and
-        standards.
-      </p>
+      <p className="skills-explained">{highlight4}</p>
     </>
   );
 };

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -1,0 +1,42 @@
+import { createContext, useContext, type ReactNode } from 'react';
+import { DEFAULT_LOCALE, defaultMessages, type Messages } from './messages';
+
+type I18nContextValue = {
+  locale: string;
+  messages: Messages;
+};
+
+const I18nContext = createContext<I18nContextValue>({
+  locale: DEFAULT_LOCALE,
+  messages: defaultMessages,
+});
+
+type TranslationProviderProps = {
+  children: ReactNode;
+  locale: string;
+  messages: Messages;
+};
+
+export function TranslationProvider({ children, locale, messages }: TranslationProviderProps): JSX.Element {
+  return <I18nContext.Provider value={{ locale, messages }}>{children}</I18nContext.Provider>;
+}
+
+type Namespace = keyof Messages;
+
+export function useTranslations(): Messages;
+export function useTranslations<K extends Namespace>(namespace: K): Messages[K];
+export function useTranslations(namespace?: Namespace) {
+  const { messages } = useContext(I18nContext);
+
+  if (!namespace) {
+    return messages;
+  }
+
+  return messages[namespace] ?? defaultMessages[namespace];
+}
+
+export function useLocale(): string {
+  const { locale } = useContext(I18nContext);
+
+  return locale;
+}

--- a/lib/messages.ts
+++ b/lib/messages.ts
@@ -1,0 +1,72 @@
+import enMessages from '../messages/en.json';
+
+export const SUPPORTED_LOCALES = ['en', 'it'] as const;
+export type Locale = (typeof SUPPORTED_LOCALES)[number];
+export const DEFAULT_LOCALE: Locale = 'en';
+
+export type Messages = typeof enMessages;
+
+export const defaultMessages: Messages = enMessages;
+
+type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends Array<infer U>
+    ? Array<U>
+    : T[K] extends Record<string, unknown>
+      ? DeepPartial<T[K]>
+      : T[K];
+};
+
+function mergeMessages(base: Messages, overrides?: DeepPartial<Messages>): Messages {
+  if (!overrides) {
+    return base;
+  }
+
+  const merge = (baseValue: unknown, overrideValue: unknown): unknown => {
+    if (overrideValue === undefined) {
+      return baseValue;
+    }
+
+    if (Array.isArray(baseValue)) {
+      return Array.isArray(overrideValue) ? overrideValue : baseValue;
+    }
+
+    if (
+      baseValue !== null &&
+      typeof baseValue === 'object' &&
+      !Array.isArray(baseValue) &&
+      overrideValue !== null &&
+      typeof overrideValue === 'object' &&
+      !Array.isArray(overrideValue)
+    ) {
+      const result: Record<string, unknown> = { ...baseValue };
+
+      for (const [key, value] of Object.entries(overrideValue as Record<string, unknown>)) {
+        result[key] = merge((baseValue as Record<string, unknown>)[key], value);
+      }
+
+      return result;
+    }
+
+    return overrideValue;
+  };
+
+  return merge(base, overrides) as Messages;
+}
+
+export async function loadMessages(locale: string): Promise<Messages> {
+  if (!SUPPORTED_LOCALES.includes(locale as Locale)) {
+    return defaultMessages;
+  }
+
+  if (locale === DEFAULT_LOCALE) {
+    return defaultMessages;
+  }
+
+  try {
+    const { default: localeMessages } = await import(`../messages/${locale}.json`);
+
+    return mergeMessages(defaultMessages, localeMessages as DeepPartial<Messages>);
+  } catch (error) {
+    return defaultMessages;
+  }
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,0 +1,97 @@
+{
+  "Seo": {
+    "title": "Jonathan Cannizzaro",
+    "titleMobile": "J.C.",
+    "description": "Portfolio of Jonathan Cannizzaro, a frontend software developer specialized in modern web technologies and user experience."
+  },
+  "Header": {
+    "brand": "JC Dev",
+    "links": {
+      "skills": "Skills",
+      "experiences": "Works",
+      "projects": "Projects",
+      "contacts": "Contacts"
+    },
+    "language": {
+      "en": "English",
+      "it": "Italiano"
+    }
+  },
+  "Greeting": {
+    "title": "Hi all, I'm Jonathan",
+    "intro": "I am a Frontend Software Developer 🚀 with experience in JavaScript, React.js, Node.js, and other libraries and frameworks. I create user-friendly and performant interfaces to enhance user experience.",
+    "skills": "My skills include responsive web development and accessibility. I stay up to date with the latest frontend technologies and trends, always seeking new challenges to improve my skills.",
+    "resumeCta": "SEE MY RESUME",
+    "resumeUrl": "http://drive.google.com/file/d/1eavvNPP9TE-ALrtxx7IPc1vQp0Lwonwg/view?usp=sharing",
+    "contactCta": "CONTACT ME",
+    "contactEmail": "jojo.can.94@gmail.com"
+  },
+  "Skills": {
+    "title": "What I Do",
+    "intro": "I am incurably curious about both front-end and back-end technologies, but my absolute passion is front-end.",
+    "highlight1": "⚡ I develop highly interactive user interfaces for your web and mobile applications.",
+    "highlight2": "⚡ Progressive Web Applications (PWA) in traditional and SPA stacks.",
+    "highlight3": "⚡ Integration of third-party services such as Firebase/AWS/Digital Ocean.",
+    "highlight4": "⚡ I also strive to optimize web accessibility and performance through best practices and standards."
+  },
+  "Education": {
+    "title": "Education",
+    "card": {
+      "institution": "Alma Mater Studiorum – University of Bologna",
+      "course": "Computer Science",
+      "period": "2019 - 2021",
+      "description": [
+        "I completed two years of the three-year Bachelor's degree program in Computer Science at the University of Bologna, gaining a strong foundation in programming, computer security, and collaboration skills through group projects.",
+        "Although I completed only two years of studies, my experience at the University of Bologna was a significant personal and professional growth opportunity."
+      ]
+    }
+  },
+  "Experiences": {
+    "title": "Experiences",
+    "cards": {
+      "syscons": {
+        "role": "Frontend Developer",
+        "company": "Syscons Interactive",
+        "location": "Via Francesco Restelli, 5, Milan, Italy",
+        "description": "I worked on internal company products and specialized in HTML, CSS, React + Redux + Saga + TypeScript, GitLab branch and repository management, Google Cloud, REST APIs, TDD & E2E testing, and agile workflows on Jira."
+      },
+      "nexum": {
+        "role": "Cloud Frontend Developer",
+        "company": "Nexum-ai",
+        "location": "Via Rodi, 49 - 00195 Rome, Italy",
+        "description": "I contributed to internal company products and focused on HTML, CSS, React + Redux + Saga + TypeScript, GitLab branch and repository management, Google Cloud, REST APIs, TDD & E2E testing, and agile practices on Jira."
+      }
+    }
+  },
+  "Projects": {
+    "title": "Projects",
+    "cards": {
+      "portfolio": {
+        "title": "Personal Portfolio",
+        "description": "A simple website built to showcase my work and skills."
+      },
+      "todo": {
+        "title": "Todo App",
+        "description": "Web application for managing daily tasks using React."
+      },
+      "api": {
+        "title": "API Experiment",
+        "description": "Small project to explore REST API integration with Node.js."
+      }
+    }
+  },
+  "Contact": {
+    "title": "Reach out to me!",
+    "subtitle": "DISCUSS A PROJECT OR JUST WANT TO SAY HI? MY INBOX IS OPEN FOR ALL.",
+    "quote": "\"Software Developer | Still Finding 💭 \"",
+    "description": "I currently work for a company as a frontend developer on ecommerce projects and I'm following three courses on Udemy: React Native, the Next.js framework, and Node.js.",
+    "location": "Bologna, Italy"
+  },
+  "Footer": {
+    "crafted": "✍️ with ❤️ by Me",
+    "themeCredit": "Theme inspired by"
+  },
+  "BackToTop": {
+    "title": "Go to top"
+  }
+}

--- a/messages/it.json
+++ b/messages/it.json
@@ -1,0 +1,97 @@
+{
+  "Seo": {
+    "title": "Jonathan Cannizzaro",
+    "titleMobile": "J.C.",
+    "description": "Portfolio di Jonathan Cannizzaro, sviluppatore frontend specializzato in tecnologie web moderne e user experience."
+  },
+  "Header": {
+    "brand": "JC Dev",
+    "links": {
+      "skills": "Competenze",
+      "experiences": "Esperienze",
+      "projects": "Progetti",
+      "contacts": "Contatti"
+    },
+    "language": {
+      "en": "Inglese",
+      "it": "Italiano"
+    }
+  },
+  "Greeting": {
+    "title": "Ciao a tutti, sono Jonathan",
+    "intro": "Sono uno Sviluppatore Frontend 🚀 con esperienza in JavaScript, React.js, Node.js e in molte altre librerie e framework. Realizzo interfacce intuitive e performanti per offrire la migliore esperienza possibile.",
+    "skills": "Le mie competenze includono sviluppo web responsive e accessibilità. Rimango aggiornato sulle ultime tecnologie e tendenze del frontend, cercando sempre nuove sfide per migliorarmi.",
+    "resumeCta": "SCOPRI IL MIO CV",
+    "resumeUrl": "http://drive.google.com/file/d/1eavvNPP9TE-ALrtxx7IPc1vQp0Lwonwg/view?usp=sharing",
+    "contactCta": "CONTATTAMI",
+    "contactEmail": "jojo.can.94@gmail.com"
+  },
+  "Skills": {
+    "title": "Cosa faccio",
+    "intro": "Sono incurabilmente curioso verso le tecnologie front-end e back-end, ma la mia vera passione resta il frontend.",
+    "highlight1": "⚡ Sviluppo interfacce utente altamente interattive per applicazioni web e mobile.",
+    "highlight2": "⚡ Progressive Web App (PWA) con stack tradizionali e SPA.",
+    "highlight3": "⚡ Integrazione di servizi di terze parti come Firebase/AWS/Digital Ocean.",
+    "highlight4": "⚡ Mi impegno a ottimizzare accessibilità e performance attraverso best practice e standard."
+  },
+  "Education": {
+    "title": "Formazione",
+    "card": {
+      "institution": "Alma Mater Studiorum – Università di Bologna",
+      "course": "Scienze Informatiche",
+      "period": "2019 - 2021",
+      "description": [
+        "Ho completato due anni del corso di laurea triennale in Scienze Informatiche all'Università di Bologna, acquisendo solide basi in programmazione, sicurezza informatica e lavoro di squadra attraverso progetti di gruppo.",
+        "Anche se ho concluso solo due anni di studi, l'esperienza all'Università di Bologna è stata una grande opportunità di crescita personale e professionale."
+      ]
+    }
+  },
+  "Experiences": {
+    "title": "Esperienze",
+    "cards": {
+      "syscons": {
+        "role": "Frontend Developer",
+        "company": "Syscons Interactive",
+        "location": "Via Francesco Restelli, 5, Milano, Italia",
+        "description": "Ho lavorato su prodotti interni dell'azienda specializzandomi in HTML, CSS, React + Redux + Saga + TypeScript, gestione di branch e repository su GitLab, Google Cloud, API REST, test TDD & E2E e processi agili su Jira."
+      },
+      "nexum": {
+        "role": "Cloud Frontend Developer",
+        "company": "Nexum-ai",
+        "location": "Via Rodi, 49 - 00195 Roma, Italia",
+        "description": "Mi sono occupato di prodotti interni dell'azienda con focus su HTML, CSS, React + Redux + Saga + TypeScript, gestione di branch e repository su GitLab, Google Cloud, API REST, test TDD & E2E e metodologie agili su Jira."
+      }
+    }
+  },
+  "Projects": {
+    "title": "Progetti",
+    "cards": {
+      "portfolio": {
+        "title": "Portfolio personale",
+        "description": "Un sito semplice per presentare il mio lavoro e le mie competenze."
+      },
+      "todo": {
+        "title": "Todo App",
+        "description": "Applicazione web per gestire le attività quotidiane realizzata con React."
+      },
+      "api": {
+        "title": "Esperimento API",
+        "description": "Un piccolo progetto per esplorare l'integrazione di API REST con Node.js."
+      }
+    }
+  },
+  "Contact": {
+    "title": "Scrivimi!",
+    "subtitle": "VUOI PARLARE DI UN PROGETTO O SEMPLICEMENTE SALUTARE? LA MIA INBOX È APERTA A TUTTI.",
+    "quote": "\"Software Developer | Sempre alla ricerca 💭 \"",
+    "description": "Lavoro come frontend developer su progetti e-commerce e sto seguendo tre corsi su Udemy: React Native, framework Next.js e Node.js.",
+    "location": "Bologna, Italia"
+  },
+  "Footer": {
+    "crafted": "✍️ con ❤️ da Me",
+    "themeCredit": "Tema ispirato da"
+  },
+  "BackToTop": {
+    "title": "Torna in cima"
+  }
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,10 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  i18n: {
+    locales: ['en', 'it'],
+    defaultLocale: 'en',
+  },
+};
+
+module.exports = nextConfig;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,6 @@
 import type { AppProps } from 'next/app';
 import { useEffect } from 'react';
+import { useRouter } from 'next/router';
 import '../styles/globals.css';
 import '../styles/header.css';
 import '../styles/greetingMain.css';
@@ -10,12 +11,25 @@ import '../styles/projects.css';
 import '../styles/reachMe.css';
 import '../styles/backToTop.css';
 
-import "bootstrap/dist/css/bootstrap.min.css";
+import 'bootstrap/dist/css/bootstrap.min.css';
+import { TranslationProvider } from '../lib/i18n';
+import { DEFAULT_LOCALE, defaultMessages, type Messages } from '../lib/messages';
 
-export default function App({ Component, pageProps }: AppProps): JSX.Element {
-    useEffect(() => {
-    import("bootstrap");
+type AppPropsWithMessages = AppProps<{ messages?: Messages }>;
+
+export default function App({ Component, pageProps }: AppPropsWithMessages): JSX.Element {
+  const router = useRouter();
+
+  useEffect(() => {
+    void import('bootstrap');
   }, []);
 
-  return <Component {...pageProps} />;
+  const locale = router.locale ?? router.defaultLocale ?? DEFAULT_LOCALE;
+  const messages = pageProps.messages ?? defaultMessages;
+
+  return (
+    <TranslationProvider locale={locale} messages={messages}>
+      <Component {...pageProps} />
+    </TranslationProvider>
+  );
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,26 +1,46 @@
-import { Html, Head, Main, NextScript } from 'next/document';
+import Document, {
+  Html,
+  Head,
+  Main,
+  NextScript,
+  type DocumentContext,
+  type DocumentInitialProps,
+} from 'next/document';
+import { DEFAULT_LOCALE } from '../lib/messages';
 
-export default function Document(): JSX.Element {
-  return (
-    <Html lang="en">
-      <Head>
-        <link rel="shortcut icon" href="#" />
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Roboto&family=Roboto+Slab&display=swap"
-          rel="stylesheet"
-        />
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/mdbootstrap/4.19.2/css/mdb.min.css" />
-        <link
-          rel="stylesheet"
-          href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
-        />
-      </Head>
-      <body>
-        <Main />
-        <NextScript />
-      </body>
-    </Html>
-  );
+class MyDocument extends Document {
+  static async getInitialProps(ctx: DocumentContext): Promise<DocumentInitialProps> {
+    const initialProps = await Document.getInitialProps(ctx);
+
+    return { ...initialProps };
+  }
+
+  render(): JSX.Element {
+    const locale = this.props.__NEXT_DATA__.locale ?? DEFAULT_LOCALE;
+
+    return (
+      <Html lang={locale}>
+        <Head>
+          <link rel="shortcut icon" href="#" />
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Roboto&family=Roboto+Slab&display=swap"
+            rel="stylesheet"
+          />
+          <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/mdbootstrap/4.19.2/css/mdb.min.css" />
+          <link
+            rel="stylesheet"
+            href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
+          />
+        </Head>
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
 }
+
+export default MyDocument;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import Head from 'next/head';
-import type { NextPage } from 'next';
+import type { GetStaticProps, NextPage } from 'next';
 import Script from 'next/script';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import BackToTopButton from '../components/BackToTopButton';
 import ContactMe from '../components/ContactMe';
 import Education from '../components/Education';
@@ -12,12 +12,41 @@ import Header from '../components/Header';
 import Projects from '../components/Projects';
 import Skills from '../components/Skills';
 import LottieWrapper from '../components/LottieWrapper';
+import { useTranslations } from '../lib/i18n';
+import { DEFAULT_LOCALE, loadMessages } from '../lib/messages';
 
 import animationdata from '../public/assets/lf20_ssmuatywSV.json';
 
 const LOTTIE_PLAYER_SELECTOR = '#firstLottie';
 
 const Home: NextPage = () => {
+  const { title, titleMobile, description } = useTranslations('Seo');
+  const [pageTitle, setPageTitle] = useState(title);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const mediaQuery = window.matchMedia('(max-width: 767px)');
+
+    const updateTitle = (matches: boolean) => {
+      setPageTitle(matches ? titleMobile : title);
+    };
+
+    updateTitle(mediaQuery.matches);
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      updateTitle(event.matches);
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
+  }, [title, titleMobile]);
+
   useEffect(() => {
     let intervalId: number | undefined;
 
@@ -64,8 +93,9 @@ const Home: NextPage = () => {
   return (
     <>
       <Head>
-        <title>Jonathan Cannizzaro</title>
+        <title>{pageTitle}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="description" content={description} />
       </Head>
       <Script
         src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js"
@@ -134,3 +164,14 @@ const Home: NextPage = () => {
 };
 
 export default Home;
+
+export const getStaticProps: GetStaticProps = async ({ locale }) => {
+  const resolvedLocale = locale ?? DEFAULT_LOCALE;
+  const messages = await loadMessages(resolvedLocale);
+
+  return {
+    props: {
+      messages,
+    },
+  };
+};


### PR DESCRIPTION
## Summary
- replace the header locale list with a compact pill-style button group
- highlight the active locale with a filled button while keeping the others outlined

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d53ebe8e1c832ba555311f02628bc9