### PR TITLE
Revamp language selector UI

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -12,6 +12,11 @@ type NavLink = {
   labelKey: NavLinkKey;
 };
 
+const LANGUAGE_FLAGS: Record<Locale, string> = {
+  en: '🇬🇧',
+  it: '🇮🇹',
+};
+
 const NAV_LINKS: NavLink[] = [
   { href: '#skills', icon: 'fas fa-code', labelKey: 'skills' },
   { href: '#experiences', icon: 'fas fa-briefcase', labelKey: 'experiences' },
@@ -28,7 +33,7 @@ const Header = (): JSX.Element => {
     SUPPORTED_LOCALES.includes(availableLocale as Locale),
   );
 
-    useEffect(() => {
+  useEffect(() => {
     if (typeof window === 'undefined') {
       return undefined;
     }
@@ -79,19 +84,25 @@ const Header = (): JSX.Element => {
                   </a>
                 </li>
               ))}
-              {availableLocales.map((availableLocale) => (
-                <li className="nav-item" key={availableLocale}>
-                  <Link
-                    href={asPath}
-                    locale={availableLocale}
-                    className={`nav-link text-center text-xxl-h3 text-xl-h4 text-lg-h5 text-sm-h6 ${
-                      availableLocale === locale ? 'active' : ''
-                    }`}
-                  >
-                    {language[availableLocale] ?? availableLocale.toUpperCase()}
-                  </Link>
-                </li>
-              ))}
+              <li className="nav-item language-selector">
+                <div className="language-switcher" role="group" aria-label="Language selector">
+                  {availableLocales.map((availableLocale) => (
+                    <Link
+                      key={availableLocale}
+                      href={asPath}
+                      locale={availableLocale}
+                      className={`language-option ${availableLocale === locale ? 'active' : ''}`}
+                    >
+                      <span aria-hidden="true" className="language-flag">
+                        {LANGUAGE_FLAGS[availableLocale] ?? '🌐'}
+                      </span>
+                      <span className="language-label">
+                        {language[availableLocale] ?? availableLocale.toUpperCase()}
+                      </span>
+                    </Link>
+                  ))}
+                </div>
+              </li>
             </ul>
           </div>
         </div>

--- a/styles/header.css
+++ b/styles/header.css
@@ -28,6 +28,57 @@
   background-color: #512da8;
 }
 
+.language-selector {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.language-switcher {
+  display: inline-flex;
+  gap: 0.5rem;
+  padding: 0.25rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.25);
+}
+
+.language-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: #fff;
+  text-decoration: none;
+  background: transparent;
+  transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.language-option:hover {
+  background: rgba(255, 255, 255, 0.18);
+  transform: translateY(-1px);
+}
+
+.language-option.active {
+  background: linear-gradient(135deg, #7b1fa2, #512da8);
+  box-shadow: 0 8px 20px rgba(81, 45, 168, 0.35);
+}
+
+.language-flag {
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.language-label {
+  text-transform: uppercase;
+}
+
 @media only screen and (max-width: 400px) {
   .navbar-brand {
     display: flex;
@@ -50,6 +101,16 @@
   .navItems {
     display: flex;
     align-items: center;
+    justify-content: center;
+  }
+
+  .language-switcher {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .language-option {
+    flex: 1 1 50%;
     justify-content: center;
   }
 }


### PR DESCRIPTION
## Summary
- restyle the header locale selector with a modern pill switcher that includes flag icons
- add updated header styles for the language selector, including active state gradients and mobile-friendly layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d55cff7c04832ba7594e47f95162f5